### PR TITLE
Typo in mcr_close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.a
 *.plist
 tags
+copychunk

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 CFLAGS=-g -Wall -Wextra -std=c99 -pedantic -fPIC
 OBJS=buffer.o nbt_loading.o nbt_parsing.o nbt_treeops.o nbt_util.o mcr.o
 
-all: nbtreader check regioninfo
+all: nbtreader check regioninfo copychunk
 
 nbtreader: main.o libnbt.a
 	$(CC) $(CFLAGS) main.o -L. -lnbt -lz -o nbtreader
@@ -19,6 +19,9 @@ check: check.c libnbt.a
 
 regioninfo: regioninfo.c libnbt.a
 	$(CC) $(CFLAGS) regioninfo.c -L. -lnbt -lz -o regioninfo
+
+copychunk: copychunk.c libnbt.a
+	$(CC) $(CFLAGS) copychunk.c -L. -lnbt -lz -o copychunk
 
 test: check
 	cd testdata && ls -1 *.nbt | xargs -n1 ../check && cd ..

--- a/copychunk.c
+++ b/copychunk.c
@@ -1,0 +1,198 @@
+#include "nbt.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#define  say(...)  printf("[CopyChunk] ");printf(__VA_ARGS__);fflush(stdout);
+#define  err(...)  fprintf(stderr,"[CopyChunk] <ERROR> ");fprintf(stderr,__VA_ARGS__);exit(1);
+#define  VERSION "0.4"
+
+// private structure
+struct MCR {
+    int fd;
+    int readonly;
+    uint32_t last_timestamp;
+    struct MCRChunk {
+        uint32_t timestamp;
+        uint32_t len;
+        unsigned char *data; // compression type + data
+    } chunk[32][32];
+};
+
+void parse_args_coords(int *x1, int *y1, int *x2, int *y2, int *rx1, int *ry1, int *rx2, int *ry2, char **argv);
+void parse_args_world(char **world_name,char **orig);
+int coord_from_char(char* input);
+int coord_normalize(int r, int l,int def);
+void region_check(char *region_filename,char *world);
+MCR* region_open(char *region_filename,char *world,int mode);
+
+void usage(void) {
+    fprintf(stderr, "\nUsage: copychunk [src] [target] [x1] [y1] [x2] [y2]");
+    fprintf(stderr, "\n     [src] and [target] are both paths to minecraft world directories");
+    fprintf(stderr, "\n     [x1] [y1] [x2] [y2] are chunk coords (not block coords) of a square region\n\n");
+    exit(1);
+}
+
+int main(int argc, char** argv) {
+    // X,Y for chunks, regions, and internal chunks, respectively
+    int x1, y1, x2, y2, rx1, ry1, rx2, ry2, ix1, iy1, ix2, iy2 = 0;
+    char* source_world;
+    char* target_world;
+    char region_filename[256];
+
+    // Check number of arguments
+    say("Version %s\n",VERSION);
+    if(argc < 7 || argc > 7) { usage(); }
+
+    // Check coordinate arguments
+    parse_args_coords(&x1,&y1,&x2,&y2,&rx1,&ry1,&rx2,&ry2,argv);
+
+    // Check the world folders exist
+    parse_args_world(&source_world,&argv[1]);
+    parse_args_world(&target_world,&argv[2]);
+
+    // Make sure all region files exist before beginning
+    for(int rx = rx1; rx <= rx2; rx++) {
+        for(int ry = ry1; ry <= ry2; ry++) {
+            sprintf(region_filename,"r.%d.%d.mca",rx,ry);
+            region_check(region_filename,source_world);
+            region_check(region_filename,target_world);
+        }
+    }
+
+    for(int rx = rx1; rx <= rx2; rx++) {
+        for(int ry = ry1; ry <= ry2; ry++) {
+            sprintf(region_filename,"r.%d.%d.mca",rx,ry);
+
+            // Normalize chunk locations relative to region 
+            ix1 = coord_normalize(rx,x1,0);
+            iy1 = coord_normalize(ry,y1,0);
+            ix2 = coord_normalize(rx,x2,31);
+            iy2 = coord_normalize(ry,y2,31);
+            
+            // Open region files
+            MCR *source = region_open(region_filename,source_world,O_RDONLY);
+            MCR *target = region_open(region_filename,target_world,O_RDWR);
+
+            say("Copying chunks (%d,%d) through (%d,%d) ... ",ix1,iy1,ix2,iy2);
+            // Walk chunks
+            int count = 0;
+            for(int x = ix1; x <= ix2; x++) {
+                for(int y = iy1; y <= iy2; y++) {
+                    count++;
+                    uint32_t timestamp = target->chunk[x][y].timestamp;
+                    mcr_chunk_set(target,x,y,mcr_chunk_get(source,x,y));
+                    target->chunk[x][y].timestamp = timestamp;
+                }
+            }
+            printf("%d chunks copied\n",count); 
+            mcr_close(source);
+
+            say("Writing target region...\n");
+            mcr_close(target);
+        }
+    }
+
+    say("All Done!\n");
+    return 0;
+}
+
+// Parse all coordinate arguments and check for validity
+void parse_args_coords(int *x1, int *y1, int *x2, int *y2, int *rx1, int *ry1, int *rx2, int *ry2, char **argv) {
+    // Read chunk coordinates
+    *x1 = coord_from_char(argv[3]);
+    *y1 = coord_from_char(argv[4]);
+    *x2 = coord_from_char(argv[5]);
+    *y2 = coord_from_char(argv[6]);
+    say("Chunk coordinates: %d,%d to %d,%d\n",*x1,*y1,*x2,*y2);
+
+    if (*x2<*x1 || *y2<*y1) {
+        err("Coordinates not in order.  Please provide numerically lower corner first.\n");
+    }
+
+    // Check region shape
+    int w = (*x2-*x1)+1;
+    int h = (*y2-*y1)+1;
+    if (w != h) {
+        err("Area specified is not square (%d by %d), aborting.\n",w,h);
+    }
+    say("%d chunks (%d by %d)\n",w*h,w,h);
+
+    // Determine region coords
+    *rx1 = *x1 >> 5;
+    *ry1 = *y1 >> 5;
+    *rx2 = *x2 >> 5;
+    *ry2 = *y2 >> 5;
+    int rh = (*rx2-*rx1)+1;
+    int rw = (*ry2-*ry1)+1;
+    say("%d region file(s): %d,%d to %d,%d\n",rh*rw,*rx1,*ry1,*rx2,*ry2);
+}
+
+// Verify world folder exists
+void parse_args_world(char **world_name,char **orig) {
+    struct stat st;
+
+    *world_name = malloc(strlen(*orig)+1);
+    strcpy(*world_name,*orig);
+
+    if(stat(*world_name,&st) != 0) {
+        err("Cannot open world folder: %s\n",*world_name);
+    }
+}
+
+// Convert a string coordinate arg to integer "safely"
+int coord_from_char(char *input) {
+    char *end;
+    int ret_val = strtol(input,&end,10);
+    if (*end) {
+        err("Error converting (%s) to integer.\n",input);
+    }
+    return ret_val;
+}
+
+// Normalize a chunk coord to its location within a region
+// If chunk lies outside the region, return "def" as a min/max bound
+int coord_normalize(int r,int l,int def) {
+    int tmp;
+    if( ((r << 5) <= l) && (((r+1) << 5) > l)) {
+        tmp = l % 32;
+        if (tmp < 0) {
+            return tmp+32;
+        } else {
+            return tmp;
+        }
+    } else {
+        return def;
+    }
+}
+
+void region_check(char *region_filename,char *world) {
+    struct stat st;
+    char *path = malloc(strlen(region_filename) + strlen(world) + 9);
+    sprintf(path,"%s/region/%s",world,region_filename);
+    if(stat(path,&st) != 0) {
+        err("A required region file does not exist: %s\n[!] All region files must exist in both worlds for successful copy.\n[!] Aborting.\n",path);
+    }
+}
+
+// Open a region file for work
+MCR *region_open(char *region_filename,char *world,int mode) {
+    char *path = malloc(strlen(region_filename) + strlen(world) + 9);
+    sprintf(path,"%s/region/%s",world,region_filename);
+    MCR *ret_region = mcr_open(path,mode);
+    if (mode == O_RDONLY) {
+        say("Opened for reading: %s\n",path);
+    } else {
+        say("Opened for writing: %s\n",path);
+    }
+    if(ret_region == NULL) {
+        err("Unknown error opening region file: %s\n",path);
+    }
+    free(path);
+    return ret_region;
+}
+
+

--- a/mcr.c
+++ b/mcr.c
@@ -139,7 +139,7 @@ int mcr_close(MCR *mcr)
             
             assert(lseek(mcr->fd, 0, SEEK_CUR)%4096 == 0);
             size_t chunkOffsetBlocks = lseek(mcr->fd, 0, SEEK_CUR) / 4096;
-            size_t chunkLenBlocks = (chunk->len+4+4095) / 4096;
+            size_t chunkLenBlocks = (chunk->len+4+4096) / 4096;
             if (chunkLenBlocks > 255) {
                 errno = EFBIG;
                 goto err;

--- a/mcr.c
+++ b/mcr.c
@@ -44,7 +44,7 @@ int _mcr_read_chunk(MCR *mcr, int x, int z, void *header)
     if (offset == 0 && nsect == 0) return 0;
     
     // timestamp
-    chunk->timestamp = ntohl(*(uint32_t*)b+4096);
+    chunk->timestamp = ntohl(*(uint32_t*)(b+4096));
     if (mcr->last_timestamp < chunk->timestamp) mcr->last_timestamp = chunk->timestamp;
     
     // read actual length

--- a/mcr.c
+++ b/mcr.c
@@ -53,7 +53,7 @@ int _mcr_read_chunk(MCR *mcr, int x, int z, void *header)
     chunk->len = ntohl(chunk->len);
     
     // read data
-    chunk->len++; // it's weird, but some libs seem to forget one byte
+    //chunk->len++; // it's weird, but some libs seem to forget one byte
     chunk->data = malloc(chunk->len);
     if (read(mcr->fd, chunk->data, chunk->len) < chunk->len-1) {
         free(chunk->data);

--- a/mcr.c
+++ b/mcr.c
@@ -53,7 +53,7 @@ int _mcr_read_chunk(MCR *mcr, int x, int z, void *header)
     chunk->len = ntohl(chunk->len);
     
     // read data
-    chunk->len++; // it's weird, but some libs seem to forget one byte
+    //chunk->len++; // it's weird, but some libs seem to forget one byte
     chunk->data = malloc(chunk->len);
     if (read(mcr->fd, chunk->data, chunk->len) < chunk->len-1) {
         free(chunk->data);
@@ -139,7 +139,7 @@ int mcr_close(MCR *mcr)
             
             assert(lseek(mcr->fd, 0, SEEK_CUR)%4096 == 0);
             size_t chunkOffsetBlocks = lseek(mcr->fd, 0, SEEK_CUR) / 4096;
-            size_t chunkLenBlocks = (chunk->len+4+4095) / 4096;
+            size_t chunkLenBlocks = (chunk->len+4+4096) / 4096;
             if (chunkLenBlocks > 255) {
                 errno = EFBIG;
                 goto err;

--- a/nbt.h
+++ b/nbt.h
@@ -44,8 +44,8 @@ typedef enum {
     TAG_STRING     = 8, /* char *, 8 bits, signed, TAG_SHORT length */
     TAG_LIST       = 9, /* X *, X bits, TAG_INT length, no names inside */
     TAG_COMPOUND   = 10, /* nbt_tag * */
-    TAG_INT_ARRAY  = 11 /* long *, 32 bits, signed, TAG_INT length */
-
+    TAG_INT_ARRAY  = 11, /* long *, 32 bits, signed, TAG_INT length */
+    TAG_LONG_ARRAY = 12  /* long long, 64 bits, signed, TAG_INT length */
 } nbt_type;
 
 typedef enum {
@@ -86,6 +86,11 @@ typedef struct nbt_node {
             int32_t *data;
             int32_t length;
         } tag_int_array;
+
+        struct nbt_long_array {
+            int64_t *data;
+            int32_t length;
+        } tag_long_array;
 
         char* tag_string; /* TODO: technically, this should be a UTF-8 string */
 

--- a/nbt_parsing.c
+++ b/nbt_parsing.c
@@ -25,6 +25,7 @@
 #else
 #include <netinet/in.h>
 #endif
+#define ntohll(x) ( ( (uint64_t)(ntohl( (uint32_t)((x << 32) >> 32) )) << 32) | ntohl( ((uint32_t)(x >> 32)) ) )     
 
 /* are we running on a little-endian system? */
 static inline int little_endian()
@@ -193,6 +194,33 @@ static inline struct nbt_int_array read_int_array(const char** memory, size_t* l
     // swap
     if (little_endian()) for(int i=0; i < ret.length; i++)
         ret.data[i] = ntohl(ret.data[i]);
+
+    return ret;
+
+parse_error:
+    if(errno == NBT_OK)
+        errno = NBT_ERR;
+
+    free(ret.data);
+    ret.data = NULL;
+    return ret;
+}
+
+static inline struct nbt_long_array read_long_array(const char** memory, size_t* length)
+{
+    struct nbt_long_array ret;
+    ret.data = NULL;
+
+    READ_GENERIC(&ret.length, sizeof ret.length, swapped_memscan, goto parse_error);
+
+    if(ret.length < 0) goto parse_error;
+
+    CHECKED_MALLOC(ret.data, 8*ret.length, goto parse_error);
+
+    READ_GENERIC(ret.data, (size_t)8*ret.length, memscan, goto parse_error);
+    // swap
+    if (little_endian()) for(int i=0; i < ret.length; i++)
+        ret.data[i] = ntohll(ret.data[i]);
 
     return ret;
 
@@ -393,6 +421,9 @@ static inline nbt_node* parse_unnamed_tag(nbt_type type, char* name, const char*
     case TAG_INT_ARRAY:
         node->payload.tag_int_array = read_int_array(memory, length);
         break;
+    case TAG_LONG_ARRAY:
+        node->payload.tag_long_array = read_long_array(memory, length);
+        break;
 
     default:
         goto parse_error; /* Unknown node or TAG_END. Either way, we shouldn't be parsing this. */
@@ -485,6 +516,16 @@ static inline void dump_int_array(const struct nbt_int_array ia, struct buffer* 
     bprintf(b, "]");
 }
 
+static inline void dump_long_array(const struct nbt_long_array la, struct buffer* b)
+{
+    assert(la.length >= 0);
+
+    bprintf(b, "[ ");
+    for(int32_t i = 0; i < la.length; ++i)
+        bprintf(b, "%d ", +la.data[i]);
+    bprintf(b, "]");
+}
+
 static inline nbt_status dump_list_contents_ascii(const struct tag_list* list, struct buffer* b, size_t ident)
 {
     const struct list_head* pos;
@@ -566,6 +607,12 @@ static inline nbt_status __nbt_dump_ascii(const nbt_node* tree, struct buffer* b
         dump_int_array(tree->payload.tag_int_array, b);
         bprintf(b, "\n");
     }
+    else if(tree->type == TAG_LONG_ARRAY)
+    {
+        bprintf(b, "TAG_Long_Array(\"%s\"): ", SAFE_NAME(tree));
+        dump_long_array(tree->payload.tag_long_array, b);
+        bprintf(b, "\n");
+    }
 
     else
         return NBT_ERR;
@@ -642,6 +689,30 @@ static nbt_status dump_int_array_binary(const struct nbt_int_array ia, struct bu
     CHECKED_APPEND(b, be_data, 4*ia.length);
 
     if (be_data != ia.data) free(be_data);
+    return NBT_OK;
+}
+
+static nbt_status dump_long_array_binary(const struct nbt_long_array la, struct buffer* b)
+{
+    int32_t dumped_length = la.length;
+
+    ne2be(&dumped_length, sizeof dumped_length);
+
+    CHECKED_APPEND(b, &dumped_length, sizeof dumped_length);
+
+    if(la.length) assert(la.data);
+
+    // big endian
+    int64_t *be_data = la.data;
+    if (little_endian()) {
+        be_data = malloc(8*la.length);
+        if (be_data == NULL) return NBT_EMEM;
+        for(int i=0; i < la.length; i++) be_data[i] = ntohll(la.data[i]);
+    }
+    
+    CHECKED_APPEND(b, be_data, 8*la.length);
+
+    if (be_data != la.data) free(be_data);
     return NBT_OK;
 }
 
@@ -777,6 +848,9 @@ static inline nbt_status __dump_binary(const nbt_node* tree, bool dump_type, str
         return dump_compound_binary(tree->payload.tag_compound, b);
     else if(tree->type == TAG_INT_ARRAY)
         return dump_int_array_binary(tree->payload.tag_int_array, b);
+    else if(tree->type == TAG_LONG_ARRAY)
+        return dump_long_array_binary(tree->payload.tag_long_array, b);
+
 
     else
         return NBT_ERR;

--- a/nbt_treeops.c
+++ b/nbt_treeops.c
@@ -66,6 +66,9 @@ void nbt_free(nbt_node* tree)
     else if(tree->type == TAG_INT_ARRAY)
         free(tree->payload.tag_int_array.data);
 
+    else if(tree->type == TAG_LONG_ARRAY)
+        free(tree->payload.tag_long_array.data);
+
     else if(tree->type == TAG_STRING)
         free(tree->payload.tag_string);
 
@@ -159,6 +162,19 @@ nbt_node* nbt_clone(nbt_node* tree)
 
         ret->payload.tag_int_array.data   = newbuf;
         ret->payload.tag_int_array.length = tree->payload.tag_int_array.length;
+    }
+
+    else if(tree->type == TAG_LONG_ARRAY)
+    {
+        int32_t* newbuf;
+        CHECKED_MALLOC(newbuf, 8*tree->payload.tag_long_array.length, goto clone_error);
+
+        memcpy(newbuf,
+               tree->payload.tag_long_array.data,
+               8*tree->payload.tag_long_array.length);
+
+        ret->payload.tag_long_array.data   = newbuf;
+        ret->payload.tag_long_array.length = tree->payload.tag_long_array.length;
     }
 
     else if(tree->type == TAG_LIST)
@@ -300,6 +316,19 @@ nbt_node* nbt_filter(const nbt_node* tree, nbt_predicate_t filter, void* aux)
                tree->payload.tag_int_array.length);
 
         ret->payload.tag_int_array.length = tree->payload.tag_int_array.length;
+    }
+
+    else if(tree->type == TAG_LONG_ARRAY)
+    {
+        CHECKED_MALLOC(ret->payload.tag_long_array.data,
+                       8*tree->payload.tag_long_array.length,
+                       goto filter_error);
+
+        memcpy(ret->payload.tag_long_array.data,
+               tree->payload.tag_long_array.data,
+               tree->payload.tag_long_array.length);
+
+        ret->payload.tag_long_array.length = tree->payload.tag_long_array.length;
     }
 
     /* Okay, we want to keep this node, but keep traversing the tree! */

--- a/nbt_util.c
+++ b/nbt_util.c
@@ -136,6 +136,11 @@ bool nbt_eq(const nbt_node* restrict a, const nbt_node* restrict b)
         return memcmp(a->payload.tag_int_array.data,
                       b->payload.tag_int_array.data,
                       4*a->payload.tag_int_array.length) == 0;
+    case TAG_LONG_ARRAY:
+        if(a->payload.tag_long_array.length != b->payload.tag_long_array.length) return false;
+        return memcmp(a->payload.tag_long_array.data,
+                      b->payload.tag_long_array.data,
+                      8*a->payload.tag_long_array.length) == 0;
 
     default: /* wtf invalid type */
         return false;


### PR DESCRIPTION
When writing an arbitary number of chunks to a region file, my code breaks unless this number is changed.  Change 4095 to 4096 and everything is perfect.  I'm guessing it was a typo?
